### PR TITLE
Found wrong naming functions

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONReader.java
+++ b/src/main/java/com/alibaba/fastjson/JSONReader.java
@@ -45,7 +45,7 @@ public class JSONReader implements Closeable {
         this.parser = parser;
     }
     
-    public void setTimzeZone(TimeZone timezone) {
+    public void setTimeZone(TimeZone timezone) {
         this.parser.lexer.setTimeZone(timezone);
     }
     
@@ -61,7 +61,7 @@ public class JSONReader implements Closeable {
         return this.parser.lexer.getLocale();
     }
     
-    public TimeZone getTimzeZone() {
+    public TimeZone getTimeZone() {
         return this.parser.lexer.getTimeZone();
     }
 


### PR DESCRIPTION
The methods names `setTimzeZone()` and `getTimzeZone()` was written wrongly.

This is a dispensable error.