### PR TITLE
Identified code duplication in JSONReader.java

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONReader.java
+++ b/src/main/java/com/alibaba/fastjson/JSONReader.java
@@ -178,9 +178,10 @@ public class JSONReader implements Closeable {
     public void close() {
         parser.close();
     }
-
-    public Integer readInteger() {
+    
+    public Object verifyObject() {
         Object object;
+
         if (context == null) {
             object = parser.parse();
         } else {
@@ -188,19 +189,18 @@ public class JSONReader implements Closeable {
             object = parser.parse();
             readAfter();
         }
+
+        return object;
+    }
+
+    public Integer readInteger() {
+        Object object = verifyObject();
 
         return TypeUtils.castToInt(object);
     }
 
     public Long readLong() {
-        Object object;
-        if (context == null) {
-            object = parser.parse();
-        } else {
-            readBefore();
-            object = parser.parse();
-            readAfter();
-        }
+        Object object = verifyObject();
 
         return TypeUtils.castToLong(object);
     }


### PR DESCRIPTION
Found code duplication in readLong and readInteger methods. It can be encapsulated in a single function to parse the context, so eliminating replication and become more readable.

This is a dispensable error.